### PR TITLE
Add a test with an email with numbers

### DIFF
--- a/src/test/java/com/fewlaps/quitnowemailsuggester/EmailSuggestorGoodEmailsTest.java
+++ b/src/test/java/com/fewlaps/quitnowemailsuggester/EmailSuggestorGoodEmailsTest.java
@@ -195,4 +195,10 @@ public class EmailSuggestorGoodEmailsTest {
         assertTrue(ev.hasGoodSyntax(email));
         assertEquals(email, es.getSuggestedEmail(email));
     }
+    
+    @Test
+    public void emailWithNumbersShouldBeValid() throws InvalidEmailException {
+        String email = "fewlaps1fewlaps@yahoo.com";
+        assertTrue(ev.hasGoodSyntax(email));
+    }
 }


### PR DESCRIPTION
A user told us that he can't create a user... and the only strange thing in his email is numbers. I'm afraid of a big bug, so let's write a test to reproduce the issue. Hope Travis pass the build.